### PR TITLE
fixed stream flow issues for large files

### DIFF
--- a/jsonStreamify.js
+++ b/jsonStreamify.js
@@ -42,7 +42,10 @@ class JSONStreamify extends CoStream {
                     // Non Object Mode are emitted as a concatinated string
                     yield this.push('"');
                     yield obj.value.pipe(new Transform({
-                        transform: (data, enc, next) => next(null, JSON.stringify(data.toString()).slice(1, -1))
+                        transform: (data, enc, next) => {
+                            this.push(JSON.stringify(data.toString()).slice(1, -1));
+                            next(null);
+                        }
                     }));
                     yield this.push('"');
                     continue;


### PR DESCRIPTION
In my use case, my team and i were attempting to stream a payload containing an image being streamed to base64 encoding (to a legacy api). 

essentially:
```
const imageStream = fs.createReadStream('image.jpeg').pipe(base64);
const jsonStream = JsonStreamStringify({image: imageStream});
jsonStream.pipe(request.post(myUrl));
```
With files roughly less than 80kb this worked correctly.
With bigger files (100kb and up), the servers we were posting to could not parse the json being sent.
Debugging I saw that data would be passed to request sometimes before it seemed to pass through jsonStreamStringify module completely. 

sending a 112kb jpeg would send
```
{
"picture":
"
iVBORw0K ...
"
gg==
}
```
instead of the desired:
```

{
"picture":
"
iVBORw0K ...
gg==
"
}
```

To reproduce just clone the repo here: https://github.com/davidmdm/image-streamer
and run the index. It sends a file to a server that only return the request body back. 

in the nodejs documentation on streams it says that: 
```
transform.prototype._transform = function(data, encoding, callback) {
  this.push(data);
  callback();
};
```
```
transform.prototype._transform = function(data, encoding, callback) {
  callback(null, data);
};
```

are equivalent since the second argument to the callback is forwarded to this.push 
However i believe some sort of odd interaction with your generator implementation or a hidden quirk in nodejs own stream implementation is causing the timing on the forwarding to be off.

By changing the one line in your repo the json gives the correct result.

