### PR TITLE
No export default in module

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Get current path begin serialized.
 ## Example Usage
 
 ```javascript
-const JsonStreamStringify = require('json-stream-stringify');
+import { JsonStreamStringify } from 'json-stream-stringify';
 
 const jsonStream = new JsonStreamStringify({
     // Promises and Streams may resolve more promises and/or streams which will be consumed and processed into json output

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "json-stream-stringify",
-  "version": "2.0.1",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/JsonStreamStringify.ts
+++ b/src/JsonStreamStringify.ts
@@ -125,7 +125,7 @@ interface IStackItemObject extends IStackItem {
 
 type VisitedWeakMap = WeakMap<any, string>;
 type VisitedWeakSet = WeakSet<any>;
-class JsonStreamStringify extends Readable {
+export class JsonStreamStringify extends Readable {
   private visited: VisitedWeakMap | VisitedWeakSet;
   private stack: IStackItem[] = [];
   private replacerFunction?: Function;
@@ -444,5 +444,3 @@ class JsonStreamStringify extends Readable {
     }) => key || index).filter(v => v || v > -1).reverse();
   }
 }
-
-export default JsonStreamStringify;

--- a/test-src/JsonStreamStringify.ts
+++ b/test-src/JsonStreamStringify.ts
@@ -1,11 +1,11 @@
 /* istanbul ignore file */
 
-// tslint:disable-next-line:import-name
-import _JsonStreamStringify from '..';
+import * as _JsonStreamStringify from '..';
 
 const isNode8orLater = parseInt(process.version.split('.')[0].slice(1), 10) >= 8;
 
 // tslint:disable:variable-name
-const JsonStreamStringify: typeof _JsonStreamStringify = isNode8orLater ? require('../lib/umd.js') : require('../lib/umd.polyfill.js');
+const exported: typeof _JsonStreamStringify = isNode8orLater ? require('../lib/umd.js') : require('../lib/umd.polyfill.js');
+const JsonStreamStringify = exported.JsonStreamStringify;
 
 export default JsonStreamStringify;


### PR DESCRIPTION
Solves #26 

Reason: https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-class-d-ts.html

```
// Note that ES6 modules cannot directly export class objects.
// This file should be imported using the CommonJS-style:
//   import x = require('[~THE MODULE~]');
//
// Alternatively, if --allowSyntheticDefaultImports or
// --esModuleInterop is turned on, this file can also be
// imported as a default import:
//   import x from '[~THE MODULE~]';
//
// Refer to the TypeScript documentation at
// https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require
// to understand common workarounds for this limitation of ES6 modules.
```