### PR TITLE
Hotfix: Empty arrays cause circular reference errors

### DIFF
--- a/src/JsonStreamStringify.ts
+++ b/src/JsonStreamStringify.ts
@@ -280,6 +280,9 @@ export class JsonStreamStringify extends Readable {
     this.item.depth = parent.depth + 1;
     if (this.indent) this.item.indent = this.indent.repeat(this.item.depth);
     this.item.path = path;
+
+    // complex items always should unvisit, primitive items already returned
+    this.unvisit(value);
   }
 
   setReadableStringItem(input: Readable, parent: Item) {


### PR DESCRIPTION
hotfix for #34

The long time solution should of course either only unvisit here or inside the specific setters.

Hope this helps others with the same problem or the people who fixx it for long time