### PR TITLE
Fix destroy being called too early

### DIFF
--- a/src/JsonStreamStringify.ts
+++ b/src/JsonStreamStringify.ts
@@ -506,6 +506,7 @@ export class JsonStreamStringify extends Readable {
       if (this.buffer.length) this.push(this.buffer);
       this.push(null);
       this.readState = ReadState.Consumed;
+      return;
     }
     if (this.readState === <any>ReadState.ReadMore) {
       this.readState = ReadState.NotReading;

--- a/src/JsonStreamStringify.ts
+++ b/src/JsonStreamStringify.ts
@@ -486,6 +486,10 @@ export class JsonStreamStringify extends Readable {
   readMore = false;
   readState: ReadState = ReadState.NotReading;
   async _read(size?: number) {
+    if (this.readState === ReadState.Consumed) {
+      this._destroy();
+      return;
+    }
     if (this.readState !== ReadState.NotReading) {
       this.readState = ReadState.ReadMore;
       return;
@@ -502,7 +506,6 @@ export class JsonStreamStringify extends Readable {
       if (this.buffer.length) this.push(this.buffer);
       this.push(null);
       this.readState = ReadState.Consumed;
-      this._destroy();
     }
     if (this.readState === <any>ReadState.ReadMore) {
       this.readState = ReadState.NotReading;


### PR DESCRIPTION
Looks like there is a race condition between consuming the last chunk of data and the `_destroy` call which can sometimes cause consumption to stall. This fixes the issue by moving the `_destroy` call to the next invocation of `_read`.

This resolves https://github.com/Faleij/json-stream-stringify/issues/39