### PR TITLE
Fix: Readable Stream read 16,384 objects

### DIFF
--- a/src/JsonStreamStringify.ts
+++ b/src/JsonStreamStringify.ts
@@ -126,7 +126,7 @@ function quoteString(string: string) {
   return str;
 }
 
-function readAsPromised(stream, size) {
+function readAsPromised(stream, size?) {
   const value = stream.read(size);
   if (value === null) {
     return new Promise((resolve, reject) => {
@@ -327,10 +327,10 @@ export class JsonStreamStringify extends Readable {
     let i = 0;
     const item = <any>{
       type: 'readable object',
-      async read(size: number) {
+      async read() {
         try {
           let out = '';
-          const data = await readAsPromised(input, size);
+          const data = await readAsPromised(input);
           if (data === null) {
             if (i && that.indent) {
               out += `\n${parent.indent}`;


### PR DESCRIPTION
Fix readebleStream in objectMode read 16,384 object and ignore highWaterMark.

my suggestion:

```js
   // function - setReadableObjectItem(input: Readable, parent: Item)
   const item = <any>{
      type: 'readable object',
      async read() {
        try {
          let out = '';
          // if send size as undefined ReadebleStream will use highWaterMark
          const data = await readAsPromised(input);
          if (data === null) {
            if (i && that.indent) {
              out += `\n${parent.indent}`;
            }
```