### PR TITLE
Fix bug with rendered empty elements in array

### DIFF
--- a/src/JsonStreamStringify.ts
+++ b/src/JsonStreamStringify.ts
@@ -42,18 +42,6 @@ function getType(value): Types {
   return Types.Primitive;
 }
 
-const stackItemOpen = [];
-stackItemOpen[Types.Array] = '[';
-stackItemOpen[Types.Object] = '{';
-stackItemOpen[Types.ReadableString] = '"';
-stackItemOpen[Types.ReadableObject] = '[';
-
-const stackItemEnd = [];
-stackItemEnd[Types.Array] = ']';
-stackItemEnd[Types.Object] = '}';
-stackItemEnd[Types.ReadableString] = '"';
-stackItemEnd[Types.ReadableObject] = ']';
-
 function escapeString(string) {
   // Modified code, original code by Douglas Crockford
   // Original: https://github.com/douglascrockford/JSON-js/blob/master/json2.js
@@ -482,13 +470,18 @@ export class JsonStreamStringify extends Readable {
     return true;
   }
 
+  // TODO: can be removed?
   reading = false;
+  // TODO: can be removed?
   readMore = false;
   readState: ReadState = ReadState.NotReading;
   async _read(size?: number) {
     if (this.readState === ReadState.Consumed) return;
     if (this.readState !== ReadState.NotReading) {
       this.readState = ReadState.ReadMore;
+      return;
+    }
+    if (this.readState === ReadState.Reading) {
       return;
     }
     this.readState = ReadState.Reading;

--- a/src/JsonStreamStringify.ts
+++ b/src/JsonStreamStringify.ts
@@ -466,6 +466,7 @@ export class JsonStreamStringify extends Readable {
     return true;
   }
 
+  readState: ReadState = ReadState.NotReading;
   async _read(size?: number) {
     if (this.readState === ReadState.Consumed) return;
     if (this.readState !== ReadState.NotReading) {

--- a/src/JsonStreamStringify.ts
+++ b/src/JsonStreamStringify.ts
@@ -481,9 +481,6 @@ export class JsonStreamStringify extends Readable {
       this.readState = ReadState.ReadMore;
       return;
     }
-    if (this.readState === ReadState.Reading) {
-      return;
-    }
     this.readState = ReadState.Reading;
     this.pushCalled = false;
     let p;
@@ -501,7 +498,7 @@ export class JsonStreamStringify extends Readable {
     }
     if (this.readState === <any>ReadState.ReadMore) {
       this.readState = ReadState.NotReading;
-      this._read(size);
+      await this._read(size);
     }
     this.readState = ReadState.NotReading;
   }


### PR DESCRIPTION
Related to https://github.com/Faleij/json-stream-stringify/issues/43

IIUC, there can be concurrent calls to _read which is why the ReadState is there (to try to avoid that case). However, because _read() is asynchronous, the nested call should do a wait, else, there is a risk of concurrent calls to _read that attempt to read.

Also, while I tried to understand the code, I broke a few things but the existing tests were not catching it, so I added a few new test cases.