### PR TITLE
call `toJSON` only AFTER `this.replacer`

### DIFF
--- a/src/JsonStreamStringify.ts
+++ b/src/JsonStreamStringify.ts
@@ -186,6 +186,11 @@ export class JsonStreamStringify extends Readable {
   }
 
   setItem(value, parent: Item, key: string | number = '') {
+    // use replacer if applicable
+    if (this.replacer) {
+      value = this.replacer.call(parent.value, key, value);
+    }
+
     // call toJSON where applicable
     if (
       value
@@ -193,11 +198,6 @@ export class JsonStreamStringify extends Readable {
       && typeof value.toJSON === 'function'
     ) {
       value = value.toJSON(key);
-    }
-
-    // use replacer if applicable
-    if (this.replacer) {
-      value = this.replacer.call(parent.value, key, value);
     }
 
     // coerece functions and symbols into undefined


### PR DESCRIPTION
replacer needs to be called before `toJSON`.

example when encoding `Buffer` I'd like to receive hex strings, but instead `toJSON` is called and my replacer is not called on `Buffer`s